### PR TITLE
avoid excessive synchronization for doMultiKeys function

### DIFF
--- a/shard_conn_factory_test.go
+++ b/shard_conn_factory_test.go
@@ -1,0 +1,58 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"github.com/bitleak/go-redis-pool/v2/hashkit"
+	"github.com/go-redis/redis/v8"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func Benchmark_doMultiKeys(b *testing.B) {
+	fn := makeMultiKeyFn()
+	keys := []string{"hello", "world", "how", "are", "you", "doing", "today?", "😊"}
+
+	for _, shardsN := range []int{4, 8, 16, 32} {
+		factory, err := setupFactory(shardsN)
+		if err != nil {
+			b.Fatalf("setup factory for %d shards failed with error: %s", shardsN, err)
+		}
+
+		b.Run(fmt.Sprintf("old: shardsN = %d", shardsN), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = factory.doMultiKeysOld(fn, keys...)
+			}
+		})
+
+		b.Run(fmt.Sprintf("new: shardsN = %d", shardsN), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = factory.doMultiKeys(fn, keys...)
+			}
+		})
+	}
+}
+
+func setupFactory(shardsN int) (*ShardConnFactory, error) {
+	shards := make([]*HAConfig, 0, 0)
+	for i := 0; i < shardsN; i++ {
+		shards = append(shards, &HAConfig{
+			Master: fmt.Sprintf("127.0.0.%d:6379", i),
+		})
+	}
+
+	return NewShardConnFactory(&ShardConfig{
+		Shards:         shards,
+		DistributeType: DistributeByModular,
+		HashFn:         hashkit.Xxh3,
+	})
+}
+
+func makeMultiKeyFn() multiKeyFn {
+	return func(factory *ShardConnFactory, keys ...string) redis.Cmder {
+		// network delay and operation execution simulation
+		time.Sleep(time.Millisecond + time.Duration(500*rand.Float64())*time.Microsecond)
+		return redis.NewStringCmd(context.Background(), keys)
+	}
+}


### PR DESCRIPTION
Benchmarks on MacBook Pro (14-inch, 2021), Apple M1 Pro, 32 GB
```bash
$ go test -test.bench '^\QBenchmark_doMultiKeys' -test.run '^$' -benchmem -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/bitleak/go-redis-pool/v2
Benchmark_doMultiKeys/old:_shardsN_=_4-10                  22496           1600952 ns/op            1984 B/op         48 allocs/op
Benchmark_doMultiKeys/new:_shardsN_=_4-10                  25048           1442641 ns/op            1960 B/op         44 allocs/op
Benchmark_doMultiKeys/old:_shardsN_=_8-10                  21718           1634431 ns/op            2672 B/op         61 allocs/op
Benchmark_doMultiKeys/new:_shardsN_=_8-10                  24517           1465809 ns/op            2585 B/op         56 allocs/op
Benchmark_doMultiKeys/old:_shardsN_=_16-10                 21475           1673454 ns/op            2968 B/op         67 allocs/op
Benchmark_doMultiKeys/new:_shardsN_=_16-10                 24558           1469097 ns/op            2912 B/op         62 allocs/op
Benchmark_doMultiKeys/old:_shardsN_=_32-10                 21578           1664476 ns/op            2968 B/op         67 allocs/op
Benchmark_doMultiKeys/new:_shardsN_=_32-10                 24464           1473660 ns/op            2912 B/op         62 allocs/op
PASS
ok      github.com/bitleak/go-redis-pool/v2     413.659s
```

- About 10% latency improvements for requests with duration in 1-1.5 ms
- About additional 100 RPS throughput improvements